### PR TITLE
Dockerfile: Update Spark version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y \
         default-jre-headless \
         python-minimal \
         wget \
-&& wget -qO- http://www-us.apache.org/dist/spark/spark-1.6.1/spark-1.6.1-bin-hadoop2.6.tgz | tar -xzf - \
+&& wget -qO- http://www-us.apache.org/dist/spark/spark-1.6.3/spark-1.6.3-bin-hadoop2.6.tgz | tar -xzf - \
 && mv /spark* /spark \
 && wget -qO- https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.38.tar.gz | tar -xzf - \
 && mv /mysql-connector-java* /mysql-connector-java \


### PR DESCRIPTION
This commit updates the Dockerfile to install Spark 1.6.3 rather than
1.6.1 because 1.6.1 is no longer available.