### PR TITLE
spark: Allow all nodes to access public on 80

### DIFF
--- a/spark.js
+++ b/spark.js
@@ -33,15 +33,16 @@ function Spark(nWorker) {
   allow(this.workers, this.workers, 7077);
   allow(this.workers, this.master, 7077);
 
+  // XXX: This is only necessary so that spark nodes can ask an external
+  // service what their public IP is.  Once this information can be passed in
+  // through an environment variable, these ACLs should be removed.
+  publicInternet.allowFrom(this.workers, 80);
+  publicInternet.allowFrom(this.master, 80);
+
   this.exposeUIToPublic = function exposeUIToPublic() {
     allow(publicInternet, this.master, 8080);
     allow(publicInternet, this.workers, 8081);
 
-    // XXX: This is only necessary so that spark nodes can ask an external
-    // service what their public IP is.  Once this information can be passed in
-    // through an environment variable, these ACLs should be removed.
-    publicInternet.allowFrom(this.workers, 80);
-    publicInternet.allowFrom(this.master, 80);
     return this;
   };
 


### PR DESCRIPTION
Even if a spark node doesn't expose its UI to public, the container
still checks it's public IP by accessing an external service on 80.
The best solution to this problem is to tell the spark containers
their IP through an environment variable, but until that's possible
this patch just opens up the port.