### PR TITLE
sparkRun: Call `deploy` on Spark rather than inf

### DIFF
--- a/sparkRun.js
+++ b/sparkRun.js
@@ -8,4 +8,4 @@ const workerVMs = inf.machines.filter(machine => machine.role === 'Worker');
 const s = new spark.Spark(workerVMs.length - 1);
 s.exposeUIToPublic();
 
-inf.deploy(s);
+s.deploy(inf);


### PR DESCRIPTION
An upcoming commit, removes the `deploy` method of the Infrastructure class,
so we should instead call `deploy` on the Spark object.