### PR TITLE
blueprint: Remove use of kelda.hostIP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,14 @@ Maintainer Ethan J. Jackson
 
 RUN apt-get update && apt-get install -y \
         default-jre-headless \
+	# wget is used to download Spark, and is used (once the container starts) to
+	# get the container's public IP address by reading checkip.amazonaws.com.
         wget \
 && wget -qO- https://www-us.apache.org/dist/spark/spark-2.2.0/spark-2.2.0-bin-hadoop2.7.tgz | tar -xzf - \
 && mv /spark* /spark \
 # Add the AWS jars so Spark can connect to S3.
 && wget -q -O /spark/jars/aws-java-sdk.jar https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk/1.7.4/aws-java-sdk-1.7.4.jar \
 && wget -q -O /spark/jars/hadoop-aws.jar https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/2.7.3/hadoop-aws-2.7.3.jar \
-&& apt-get remove --purge -y wget \
-&& apt-get autoremove --purge -y \
 && rm -rf /var/lib/lists/* /tmp/* /var/tmp/*
 
 # Create a directory for the Spark event log, which stores information about

--- a/spark-env.sh
+++ b/spark-env.sh
@@ -1,0 +1,2 @@
+# Set Spark's public IP address so that the links in the UI work.
+export SPARK_PUBLIC_DNS=`wget -q -O - http://checkip.amazonaws.com`


### PR DESCRIPTION
`kelda.hostIP` will not be supported after Kelda is modified to run
on top of Kubernetes, so this commit makes it so Spark fetches its
public IP at container runtime.