### PR TITLE
blueprint: Use new constructor format

### DIFF
--- a/spark.js
+++ b/spark.js
@@ -143,7 +143,9 @@ class Spark {
     // Hadoop.
     const env = { HADOOP_CONF_DIR: '/spark/conf/' };
 
-    this.master = new Container('spark-master', image, {
+    this.master = new Container({
+      name: 'spark-master',
+      image,
       command: ['/spark/bin/spark-class', 'org.apache.spark.deploy.master.Master'],
       filepathToContent: sparkConfigFiles,
       env,
@@ -153,7 +155,9 @@ class Spark {
 
     this.workers = [];
     for (let i = 0; i < nWorker; i += 1) {
-      this.workers.push(new Container('spark-worker', image, {
+      this.workers.push(new Container({
+        name: 'spark-worker',
+        image,
         command: [
           '/spark/bin/spark-class',
           'org.apache.spark.deploy.worker.Worker',
@@ -203,7 +207,9 @@ class Spark {
    * @returns {void}
    */
   addDriver(configFiles) {
-    this.driver = new Container('spark-driver', image, {
+    this.driver = new Container({
+      name: 'spark-driver',
+      image,
       // When we start the container, start the history server. The command to start the
       // history server starts it as a daemon, so we need to add a second, long-running command
       // to ensure that the container doesn't exit.

--- a/sparkRun.js
+++ b/sparkRun.js
@@ -3,10 +3,8 @@ const spark = require('./spark.js');
 
 const inf = kelda.baseInfrastructure();
 
-const workerVMs = inf.machines.filter(machine => machine.role === 'Worker');
-
-const s = new spark.Spark(workerVMs.length - 1,
-  { memoryMiB: spark.getWorkerMemoryMiB(workerVMs[0]) });
+const s = new spark.Spark(inf.workers.length - 1,
+  { memoryMiB: spark.getWorkerMemoryMiB(inf.workers[0]) });
 s.exposeUIToPublic();
 
 s.deploy(inf);

--- a/sparkWithHDFSExample.js
+++ b/sparkWithHDFSExample.js
@@ -4,7 +4,10 @@ const hadoop = require('@kelda/hadoop');
 
 const numSparkWorkers = 2;
 const machine = new kelda.Machine({ provider: 'Amazon', size: 'm4.large' });
-const inf = new kelda.Infrastructure(machine, machine.replicate(numSparkWorkers + 1));
+const inf = new kelda.Infrastructure({
+  masters: machine,
+  workers: machine.replicate(numSparkWorkers + 1),
+});
 
 const hdfs = new hadoop.HDFS(numSparkWorkers);
 hdfs.exposeUIToPublic();

--- a/testInfra.js
+++ b/testInfra.js
@@ -1,7 +1,10 @@
 // This file contains the base infrastructure used for the travis build.
 function infraGetter(kelda) {
   const vmTemplate = new kelda.Machine({ provider: 'Amazon' });
-  return new kelda.Infrastructure(vmTemplate, vmTemplate.replicate(3));
+  return new kelda.Infrastructure({
+    masters: vmTemplate,
+    workers: vmTemplate.replicate(3),
+  });
 }
 
 module.exports = infraGetter;


### PR DESCRIPTION
The build will fail until the next release of Kelda (0.10.0). This should not be merged until then.